### PR TITLE
fix: server._requests doesn't use new server_key

### DIFF
--- a/prc/client.py
+++ b/prc/client.py
@@ -72,9 +72,14 @@ class PRC:
 
         existing_server = self._global_cache.servers.get(server_id)
         if existing_server and existing_server._ignore_global_key == ignore_global_key:
-            if existing_server._server_key != server_key:
+            if (
+                existing_server._global_key != self._global_key
+                or existing_server._server_key != server_key
+            ):
+                existing_server._global_key = self._global_key
                 existing_server._server_key = server_key
                 existing_server._refresh_requests()
+
                 return self._global_cache.servers.set(server_id, existing_server)
             else:
                 return existing_server

--- a/prc/client.py
+++ b/prc/client.py
@@ -72,7 +72,12 @@ class PRC:
 
         existing_server = self._global_cache.servers.get(server_id)
         if existing_server and existing_server._ignore_global_key == ignore_global_key:
-            return existing_server
+            if existing_server._server_key != server_key:
+                existing_server._server_key = server_key
+                existing_server._refresh_requests()
+                return self._global_cache.servers.set(server_id, existing_server)
+            else:
+                return existing_server
         return self._global_cache.servers.set(
             server_id,
             Server(

--- a/prc/client.py
+++ b/prc/client.py
@@ -83,12 +83,15 @@ class PRC:
                 return self._global_cache.servers.set(server_id, existing_server)
             else:
                 return existing_server
-        return self._global_cache.servers.set(
-            server_id,
-            Server(
-                client=self, server_key=server_key, ignore_global_key=ignore_global_key
-            ),
-        )
+        else:
+            return self._global_cache.servers.set(
+                server_id,
+                Server(
+                    client=self,
+                    server_key=server_key,
+                    ignore_global_key=ignore_global_key,
+                ),
+            )
 
     async def get_stats(self):
         """Get game statistics (ER:LC) using the PRC public statistics API."""

--- a/prc/server.py
+++ b/prc/server.py
@@ -85,6 +85,7 @@ class Server:
         self._server_cache = cache
         self._ephemeral_ttl = ephemeral_ttl
 
+        self._global_key = client._global_key
         self._server_key = server_key
         self._requests = requests or self._refresh_requests()
         self._ignore_global_key = ignore_global_key
@@ -116,7 +117,7 @@ class Server:
         )
 
     def _refresh_requests(self):
-        global_key = self._client._global_key
+        global_key = self._global_key
         headers = {"Server-Key": self._server_key}
         if global_key and not self._ignore_global_key:
             headers["Authorization"] = global_key

--- a/prc/server.py
+++ b/prc/server.py
@@ -85,15 +85,8 @@ class Server:
         self._server_cache = cache
         self._ephemeral_ttl = ephemeral_ttl
 
-        global_key = client._global_key
-        headers = {"Server-Key": server_key}
-        if global_key and not ignore_global_key:
-            headers["Authorization"] = global_key
-        self._requests = requests or Requests(
-            base_url=client._base_url + "/server",
-            headers=headers,
-            session=client._session,
-        )
+        self._server_key = server_key
+        self._requests = requests or self._refresh_requests()
         self._ignore_global_key = ignore_global_key
 
         self.logs = ServerLogs(self)
@@ -121,6 +114,18 @@ class Server:
             if self.join_code
             else None
         )
+
+    def _refresh_requests(self):
+        global_key = self._client._global_key
+        headers = {"Server-Key": self._server_key}
+        if global_key and not self._ignore_global_key:
+            headers["Authorization"] = global_key
+        self._requests = Requests(
+            base_url=self._client._base_url + "/server",
+            headers=headers,
+            session=self._client._session,
+        )
+        return self._requests
 
     def _get_player(self, id: Optional[int] = None, name: Optional[str] = None):
         for _, player in self._server_cache.players.items():
@@ -307,8 +312,8 @@ class ServerLogs(ServerModule):
 
 
 CommandTargetPlayerName = str
-CommandTargetPlayerID = int
-CommandTargetPlayerNameOrID = Union[CommandTargetPlayerName, CommandTargetPlayerID]
+CommandTargetPlayerId = int
+CommandTargetPlayerNameOrId = Union[CommandTargetPlayerName, CommandTargetPlayerId]
 
 
 class ServerCommands(ServerModule):
@@ -327,7 +332,7 @@ class ServerCommands(ServerModule):
     async def run(
         self,
         name: CommandName,
-        targets: Optional[Sequence[CommandTargetPlayerNameOrID]] = None,
+        targets: Optional[Sequence[CommandTargetPlayerNameOrId]] = None,
         args: Optional[List[CommandArg]] = None,
         text: Optional[str] = None,
     ):
@@ -397,35 +402,35 @@ class ServerCommands(ServerModule):
         """Kick players from the server."""
         await self.run("kick", targets=targets, text=reason)
 
-    async def ban(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def ban(self, targets: List[CommandTargetPlayerNameOrId]):
         """Ban players from the server."""
         await self.run("ban", targets=targets)
 
-    async def unban(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def unban(self, targets: List[CommandTargetPlayerNameOrId]):
         """Unban players from the server."""
         await self.run("unban", targets=targets)
 
-    async def grant_helper(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def grant_helper(self, targets: List[CommandTargetPlayerNameOrId]):
         """Grant helper permissions to players in the server."""
         await self.run("helper", targets=targets)
 
-    async def revoke_helper(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def revoke_helper(self, targets: List[CommandTargetPlayerNameOrId]):
         """Revoke helper permissions to players in the server."""
         await self.run("unhelper", targets=targets)
 
-    async def grant_mod(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def grant_mod(self, targets: List[CommandTargetPlayerNameOrId]):
         """Grant moderator permissions to players in the server."""
         await self.run("mod", targets=targets)
 
-    async def revoke_mod(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def revoke_mod(self, targets: List[CommandTargetPlayerNameOrId]):
         """Revoke moderator permissions from players in the server."""
         await self.run("unmod", targets=targets)
 
-    async def grant_admin(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def grant_admin(self, targets: List[CommandTargetPlayerNameOrId]):
         """Grant admin permissions to players in the server."""
         await self.run("admin", targets=targets)
 
-    async def revoke_admin(self, targets: List[CommandTargetPlayerNameOrID]):
+    async def revoke_admin(self, targets: List[CommandTargetPlayerNameOrId]):
         """Revoke admin permissions from players in the server."""
         await self.run("unadmin", targets=targets)
 


### PR DESCRIPTION
Fixes a bug where `PRC.get_server()` does not update `server._requests` if new keys are being used by the client.

Code below clarifies this.

```
from prc import PRC
import asyncio

client = PRC(
    default_server_key="ABCDE-123"
)

s = client.get_server()

async def main():
    s2 = client.get_server("EFGH-123")
    await s2.get_staff()

    print("s2", s2.total_staff_count)
    print("s1", s.total_staff_count)


asyncio.run(main())
```

Previously, the request was made using the original `ABCDE...` key, which is supposed to be invalid as it has been refresh.
Same applies for global keys.